### PR TITLE
Cria seed para deputy e cost

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,48 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+deputado1 = Deputy.find_or_create_by!(ideCadastro: 1) do |d|
+  d.txNomeParlamentar = "Deputado Teste 1"
+  d.nuCarteiraParlamentar = "123"
+  d.cpf = "00000000000"
+  d.sgUF = "SP"
+  d.sgPartido = "ABC"
+end
+
+deputado2 = Deputy.find_or_create_by!(ideCadastro: 2) do |d|
+  d.txNomeParlamentar = "Deputado Teste 2"
+  d.nuCarteiraParlamentar = "456"
+  d.cpf = "11111111111"
+  d.sgUF = "RJ"
+  d.sgPartido = "DEF"
+end
+
+Cost.create!(
+  txtDescricao: "Material de Escritório",
+  txtFornecedor: "Fornecedor Exemplo",
+  txtCNPJCPF: "12345678000199",
+  datEmissao: DateTime.now - 10.days,
+  vlrLiquido: 150.75,
+  urlDocumento: "http://example.com/doc1.pdf",
+  deputy: deputado1
+)
+
+Cost.create!(
+  txtDescricao: "Serviço de Limpeza",
+  txtFornecedor: "Fornecedor Limpeza",
+  txtCNPJCPF: "98765432000155",
+  datEmissao: DateTime.now - 5.days,
+  vlrLiquido: 300.00,
+  urlDocumento: "http://example.com/doc2.pdf",
+  deputy: deputado1
+)
+
+Cost.create!(
+  txtDescricao: "Transporte",
+  txtFornecedor: "Fornecedor Transporte",
+  txtCNPJCPF: "19283746500011",
+  datEmissao: DateTime.now - 3.days,
+  vlrLiquido: 120.00,
+  urlDocumento: "http://example.com/doc3.pdf",
+  deputy: deputado2
+)
+
+puts "Deputies count: #{Deputy.count}"
+puts "Costs count: #{Cost.count}"


### PR DESCRIPTION
### 📋 Descrição

Este PR adiciona o seed básico para os modelos `Deputy` e `Cost`, com registros de exemplo para facilitar o desenvolvimento e os testes iniciais.

### ✅ Alterações principais
- Criado seed para múltiplos `Deputy`.
- Criado seed para múltiplos `Cost` associados aos `Deputy`.
- Adicionada saída no console para verificar a quantidade de registros criados após rodar o seed.

### ✅Como testar:
1. Execute `rails db:seed`.
2. Verifique a saída no console para confirmar a criação dos registros.
3. Opcionalmente, verifique diretamente no banco de dados ou via console Rails (`rails c`) os dados inseridos.

Esse seed básico vai ajudar a ter dados iniciais consistentes para o desenvolvimento das próximas funcionalidades.

### 🔗 Card relacionado
Este PR corresponde ao card #8 
